### PR TITLE
Add ability to query portal for public and private proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Add the `ocs_archive` package to your python environment:
 | FileStore | `FILESTORE_TYPE` | Type of filestorage to use. Options are `dummy`, `local`, or `s3`. | `dummy` |
 |           | `FILESYSTEM_STORAGE_ROOT_DIR` | If using `local` file storage, this is the directory on the local filesystem to use as the root of the storage directories | _empty string_ |
 |           | `FILESYSTEM_STORAGE_BASE_URL` | If using `local` file storage, this is the base URL at which those files will be hosted from | `http://0.0.0.0/` |
+| Observation Portal | `OBSERVATION_PORTAL_BASE_URL` | Base URL for the Observation Portal | _empty string_ |
+|                    | `OBSERVATION_PORTAL_API_TOKEN` | API Token used to authenticate with the Observation Portal | _empty string_ |
 | AWS | `BUCKET` | If using `s3` file storage; AWS S3 Bucket Name | `testbucket` |
 |     | `AWS_ACCESS_KEY_ID` | If using `s3` file storage; AWS Access Key with write access to the S3 bucket | _empty string_ |
 |     | `AWS_SECRET_ACCESS_KEY` | If using `s3` file storage; AWS Secret Access Key | _empty string_ |
@@ -43,6 +45,8 @@ Add the `ocs_archive` package to your python environment:
 |          | `REQUIRED_HEADERS` | Comma delimited string list of header values that must be present in the DataFile. This can be overriden when instantiating a DataFile as well as via environment variable |
 |          | `NULL_HEADER_VALUES` | Comma delimited string list of header values that should be turned into `None` or empty keys. This only applies to the FitsFile class. | `N/A,UNSPECIFIED,UNKNOWN` |
 |          | `CALIBRATION_TYPES` | Comma delimited string list of configuration types which represent calibration images. This is used to automatically set calibration images public date to be the observation date if it is not present | `BIAS,DARK,SKYFLAT,EXPERIMENTAL` |
+|          | `PUBLIC_PROPOSAL_TAGS` | A comma delimited string list of Observation Portal proposal tags to denote data from this proposal as public. If public, the public date will be set to the observation date. The ocs_archive will fall back to the list of `PUBLIC_PROPOSALS` if any of a proposal's tags are not found in this list. | `public` |
+|          | `PRIVATE_PROPOSAL_TAGS` | A comma delimited string list of Observation Portal proposal tags to denote data from this proposal as private. If private, the public date will be set to 999 years in the future. The ocs_archive will fall back to the list of `PRIVATE_PROPOSALS` if any of a proposal's tags are not found in this list. | `private,internal` |
 |          | `PUBLIC_PROPOSALS` | Comma delimited string list of proposal IDs which represent public proposals. This is used to set the public date of observations under those proposals to the observation date if it is not present. The matching is based on if each character group appears anywhere within the proposal ID | `EPO,calib,standard,pointing` |
 |          | `PRIVATE_PROPOSALS` | A comma delimited string list of proposal IDs which represent private proposals. This is used to set the public date of the observations under those proposals to be 999 years in the future. The matching is based on if each character group appears anywhere within the proposal ID | `LCOEngineering` |
 |          | `DAYS_UNTIL_PUBLIC` | The number of days until user data becomes public by default. This is added onto the observation date to get the public date if one is not specifed with the data | `365` |

--- a/ocs_archive/input/file.py
+++ b/ocs_archive/input/file.py
@@ -105,7 +105,7 @@ class DataFile:
     @property
     @lru_cache()
     def proposal_tags(self):
-        """Return the tags associated with a proposal in the Observation Portal"""
+        """Return the tags associated with a proposal in the Observation Portal."""
         # If the observation portal connection isn't configured, don't try and fetch proposal tags
         if None in [settings.OBSERVATION_PORTAL_BASE_URL, settings.OBSERVATION_PORTAL_API_TOKEN]:
             return None
@@ -122,8 +122,8 @@ class DataFile:
 
     @property
     def data_privacy_tags(self):
-        """ Given a set of proposal tags, return tags that match tags defined as data privacy tags
-        
+        """Given a set of proposal tags, return tags that match tags defined as data privacy tags.
+    
         These are tags defined in settings.PRIVATE_PROPOSAL_TAGS and settings.PUBLIC_PROPOSAL_TAGS
         """
         if self.proposal_tags is not None:

--- a/ocs_archive/input/file.py
+++ b/ocs_archive/input/file.py
@@ -9,7 +9,7 @@ from dateutil.parser import parse
 from astropy import wcs, units
 from astropy.coordinates import Angle
 import requests
-from functools import cached_property
+from functools import lru_cache
 from requests.models import HTTPError
 
 from ocs_archive.settings import settings
@@ -102,7 +102,8 @@ class DataFile:
         self._repair_observation_day()
         self._repair_public_date()
 
-    @cached_property
+    @property
+    @lru_cache()
     def proposal_tags(self):
         """ Return the tags associated with a proposal in the Observation Portal
         """

--- a/ocs_archive/input/file.py
+++ b/ocs_archive/input/file.py
@@ -122,7 +122,7 @@ class DataFile:
 
     @property
     def data_privacy_tags(self):
-        """Given a set of proposal tags, return tags that match tags defined as data privacy tags.
+        """Given a set of proposal tags, return tags that match tags defined as data privacy tags
 
         These are tags defined in settings.PRIVATE_PROPOSAL_TAGS and settings.PUBLIC_PROPOSAL_TAGS
         """
@@ -154,7 +154,7 @@ class DataFile:
             if observation_date:
                 observation_day = observation_date.split('T')[0].replace('-', '')
                 self.header_data.update_headers({settings.OBSERVATION_DAY_KEY: observation_day})
-    
+
     def _repair_public_date(self):
         # Set the public date based on observation date. Should be overriden if you have another method
         # of specifying the public date in your file type

--- a/ocs_archive/input/file.py
+++ b/ocs_archive/input/file.py
@@ -105,16 +105,15 @@ class DataFile:
     @property
     @lru_cache()
     def proposal_tags(self):
-        """ Return the tags associated with a proposal in the Observation Portal
-        """
+        """Return the tags associated with a proposal in the Observation Portal"""
         # If the observation portal connection isn't configured, don't try and fetch proposal tags
         if None in [settings.OBSERVATION_PORTAL_BASE_URL, settings.OBSERVATION_PORTAL_API_TOKEN]:
             return None
-        
+
         proposal_id = self.header_data.get_proposal_id()
         proposal_url = urljoin(settings.OBSERVATION_PORTAL_BASE_URL, f'/api/proposals/{proposal_id}')
         try:
-            response = requests.get(proposal_url, 
+            response = requests.get(proposal_url,
                                     headers={'Authorization': f'Token {settings.OBSERVATION_PORTAL_API_TOKEN}'})
             response.raise_for_status()
         except HTTPError:
@@ -124,6 +123,7 @@ class DataFile:
     @property
     def data_privacy_tags(self):
         """ Given a set of proposal tags, return tags that match tags defined as data privacy tags
+        
         These are tags defined in settings.PRIVATE_PROPOSAL_TAGS and settings.PUBLIC_PROPOSAL_TAGS
         """
         if self.proposal_tags is not None:

--- a/ocs_archive/input/file.py
+++ b/ocs_archive/input/file.py
@@ -2,10 +2,15 @@ from datetime import timedelta
 import hashlib
 import os
 import io
+from urllib.parse import urljoin
+import itertools
 
 from dateutil.parser import parse
 from astropy import wcs, units
 from astropy.coordinates import Angle
+import requests
+from functools import cached_property
+from requests.models import HTTPError
 
 from ocs_archive.settings import settings
 from ocs_archive.input.headerdata import HeaderData
@@ -97,6 +102,35 @@ class DataFile:
         self._repair_observation_day()
         self._repair_public_date()
 
+    @cached_property
+    def proposal_tags(self):
+        """ Return the tags associated with a proposal in the Observation Portal
+        """
+        # If the observation portal connection isn't configured, don't try and fetch proposal tags
+        if None in [settings.OBSERVATION_PORTAL_BASE_URL, settings.OBSERVATION_PORTAL_API_TOKEN]:
+            return None
+        
+        proposal_id = self.header_data.get_proposal_id()
+        proposal_url = urljoin(settings.OBSERVATION_PORTAL_BASE_URL, f'/api/proposals/{proposal_id}')
+        try:
+            response = requests.get(proposal_url, 
+                                    headers={'Authorization': f'Token {settings.OBSERVATION_PORTAL_API_TOKEN}'})
+            response.raise_for_status()
+        except HTTPError:
+            return None
+        return response.json()['tags']
+
+    @property
+    def data_privacy_tags(self):
+        """ Given a set of proposal tags, return tags that match tags defined as data privacy tags
+        These are tags defined in settings.PRIVATE_PROPOSAL_TAGS and settings.PUBLIC_PROPOSAL_TAGS
+        """
+        if self.proposal_tags is not None:
+            privacy_tags = [tag for tag in self.proposal_tags if tag in itertools.chain(settings.PRIVATE_PROPOSAL_TAGS, settings.PUBLIC_PROPOSAL_TAGS)]
+            return privacy_tags if privacy_tags != [] else None
+        else:
+            return None
+
     def _create_header_data(self, file_metadata: dict):
         if self._is_valid_file_metadata(file_metadata):
             self.header_data = HeaderData(file_metadata)
@@ -119,21 +153,31 @@ class DataFile:
             if observation_date:
                 observation_day = observation_date.split('T')[0].replace('-', '')
                 self.header_data.update_headers({settings.OBSERVATION_DAY_KEY: observation_day})
-
+    
     def _repair_public_date(self):
         # Set the public date based on observation date. Should be overriden if you have another method
         # of specifying the public date in your file type
         if not self.header_data.get_public_date():
-            if (self.header_data.get_configuration_type() in settings.CALIBRATION_TYPES or
-                    (self.header_data.get_proposal_id() and any([prop in self.header_data.get_proposal_id() for prop in settings.PUBLIC_PROPOSALS]))):
-                public_date = self.header_data.get_observation_date()
-            elif ((self.header_data.get_proposal_id() and any([prop in self.header_data.get_proposal_id() for prop in settings.PRIVATE_PROPOSALS])) or
-                    any([chars in self.open_file.basename for chars in settings.PRIVATE_FILE_TYPES])):
-                # This should be private, set it to 999 years from observation date
-                public_date = (parse(self.header_data.get_observation_date()) + timedelta(days=365 * 999)).isoformat()
+            # Check if the proposal is denoted as public or private in the observation portal
+            if self.data_privacy_tags:
+                if any([tag in settings.PRIVATE_PROPOSAL_TAGS for tag in self.proposal_tags]):
+                    public_date = (parse(self.header_data.get_observation_date()) + timedelta(days=365 * 999)).isoformat()
+                elif any([tag in settings.PUBLIC_PROPOSAL_TAGS for tag in self.proposal_tags]):
+                    public_date = self.header_data.get_observation_date()
             else:
-                # This should be proprietary, set it to X days from observation date
-                public_date = (parse(self.header_data.get_observation_date()) + timedelta(days=settings.DAYS_UNTIL_PUBLIC)).isoformat()
+                # If it's a calibration frame, it's immediately pubic
+                if (self.header_data.get_configuration_type() in settings.CALIBRATION_TYPES or
+                        (self.header_data.get_proposal_id() and any([prop in self.header_data.get_proposal_id() for prop in settings.PUBLIC_PROPOSALS]))):
+                    public_date = self.header_data.get_observation_date()
+                # If the proposal is set to private or the file type is a private file type, make it private forever
+                elif ((self.header_data.get_proposal_id() and any([prop in self.header_data.get_proposal_id() for prop in settings.PRIVATE_PROPOSALS])) or
+                        any([chars in self.open_file.basename for chars in settings.PRIVATE_FILE_TYPES])):
+                    public_date = (parse(self.header_data.get_observation_date()) + timedelta(days=365 * 999)).isoformat()
+                # Finally, if none of these, make it proprietary
+                else:
+                    # This should be proprietary, set it to X days from observation date
+                    public_date = (parse(self.header_data.get_observation_date()) + timedelta(days=settings.DAYS_UNTIL_PUBLIC)).isoformat()
+            
             self.header_data.update_headers({settings.PUBLIC_DATE_KEY: public_date})
 
     def _is_valid_file_metadata(self, metadata_dict: dict):

--- a/ocs_archive/input/file.py
+++ b/ocs_archive/input/file.py
@@ -123,7 +123,7 @@ class DataFile:
     @property
     def data_privacy_tags(self):
         """Given a set of proposal tags, return tags that match tags defined as data privacy tags.
-    
+
         These are tags defined in settings.PRIVATE_PROPOSAL_TAGS and settings.PUBLIC_PROPOSAL_TAGS
         """
         if self.proposal_tags is not None:

--- a/ocs_archive/input/file.py
+++ b/ocs_archive/input/file.py
@@ -128,9 +128,9 @@ class DataFile:
         """
         if self.proposal_tags is not None:
             privacy_tags = [tag for tag in self.proposal_tags if tag in itertools.chain(settings.PRIVATE_PROPOSAL_TAGS, settings.PUBLIC_PROPOSAL_TAGS)]
-            return privacy_tags if privacy_tags != [] else None
+            return privacy_tags
         else:
-            return None
+            return []
 
     def _create_header_data(self, file_metadata: dict):
         if self._is_valid_file_metadata(file_metadata):
@@ -160,11 +160,10 @@ class DataFile:
         # of specifying the public date in your file type
         if not self.header_data.get_public_date():
             # Check if the proposal is denoted as public or private in the observation portal
-            if self.data_privacy_tags:
-                if any([tag in settings.PRIVATE_PROPOSAL_TAGS for tag in self.proposal_tags]):
-                    public_date = (parse(self.header_data.get_observation_date()) + timedelta(days=365 * 999)).isoformat()
-                elif any([tag in settings.PUBLIC_PROPOSAL_TAGS for tag in self.proposal_tags]):
-                    public_date = self.header_data.get_observation_date()
+            if any([tag in settings.PRIVATE_PROPOSAL_TAGS for tag in self.data_privacy_tags]):
+                public_date = (parse(self.header_data.get_observation_date()) + timedelta(days=365 * 999)).isoformat()
+            elif any([tag in settings.PUBLIC_PROPOSAL_TAGS for tag in self.data_privacy_tags]):
+                public_date = self.header_data.get_observation_date()
             else:
                 # If it's a calibration frame, it's immediately pubic
                 if (self.header_data.get_configuration_type() in settings.CALIBRATION_TYPES or

--- a/ocs_archive/settings/settings.py
+++ b/ocs_archive/settings/settings.py
@@ -19,6 +19,14 @@ FILESTORE_TYPE = os.getenv('FILESTORE_TYPE', 'dummy')
 FILESYSTEM_STORAGE_ROOT_DIR = os.getenv('FILESYSTEM_STORAGE_ROOT_DIR', '')
 FILESYSTEM_STORAGE_BASE_URL = os.getenv('FILESYSTEM_STORAGE_BASE_URL', 'http://0.0.0.0/')
 
+# Used to specify the location and authentication details for the Observation Portal
+OBSERVATION_PORTAL_BASE_URL = os.getenv('OBSERVATION_PORTAL_BASE_URL')
+OBSERVATION_PORTAL_API_TOKEN = os.getenv('OBSERVATION_PORTAL_API_TOKEN')
+
+# Used to specify the proposal tags that denote whether the data from a proposal should be public or private
+PRIVATE_PROPOSAL_TAGS = get_tuple_from_environment('PRIVATE_PROPOSAL_TAGS', 'private,internal')
+PUBLIC_PROPOSAL_TAGS = get_tuple_from_environment('PRIVATE_PROPOSAL_TAGS', 'public')
+
 # Used to override and update mapping of file extensions to DataFile subclass class dotpath
 # The expected format is a string literal representation of a dictionary, mapping extensions
 # to Datafile subclass absolute dotpath

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,10 @@ setup(
         'astropy',
         'boto3',
         'python-dateutil',
+        'requests==2.26.0'
     ],
     extras_require={
-        'tests': ['pytest']
+        'tests': ['pytest',
+                  'responses==0.16.0']
     }
 )

--- a/tests/test_datafiles.py
+++ b/tests/test_datafiles.py
@@ -134,7 +134,7 @@ class TestDataFile(unittest.TestCase):
 
     @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_BASE_URL', 'https://obs.portal/')
     @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_API_TOKEN', 'asdf')
-    @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSAL_TAGS', ('private',))
+    @patch('ocs_archive.input.file.settings.PRIVATE_PROPOSAL_TAGS', ('private',))
     @responses.activate
     def test_private_in_portal(self):
         headers = {
@@ -151,7 +151,7 @@ class TestDataFile(unittest.TestCase):
     @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSALS', ('EPOTHING',))
     @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_BASE_URL', 'https://obs.portal/')
     @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_API_TOKEN', 'asdf')
-    @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSAL_TAGS', ('private',))
+    @patch('ocs_archive.input.file.settings.PRIVATE_PROPOSAL_TAGS', ('private',))
     @responses.activate
     def test_no_data_privacy_tags_falls_back_to_environment_variables(self):
         headers = {

--- a/tests/test_datafiles.py
+++ b/tests/test_datafiles.py
@@ -165,6 +165,23 @@ class TestDataFile(unittest.TestCase):
         header_data = data_file.get_header_data()
         self.assertEqual(header_data.get_public_date(), header_data.get_observation_date())
 
+    @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSALS', ('MYPUBLICPROP',))
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_BASE_URL', 'https://obs.portal/')
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_API_TOKEN', 'asdf')
+    @patch('ocs_archive.input.file.settings.PRIVATE_PROPOSAL_TAGS', ('private',))
+    @responses.activate
+    def test_500_error_fallback_to_environment_variable(self):
+        headers = {
+            'PROPID': 'MYPUBLICPROP',
+            'DATE-OBS': '2016-04-01T00:00:00+00:00',
+            'OBSTYPE': 'EXPOSE'
+        }
+        responses.add(responses.GET, 'https://obs.portal/api/proposals/MYPUBLICPROP',
+                      status=500)
+        data_file = DataFile(self.file, file_metadata=headers, required_headers=[])
+        header_data = data_file.get_header_data()
+        self.assertEqual(header_data.get_public_date(), header_data.get_observation_date())
+
     def test_get_wcs_corners_from_dict_for_ccd(self):
         headers = {'CD1_1': 6, 'CD1_2': 2, 'CD2_1': 3, 'CD2_2': 4, 'NAXIS1': 1000, 'NAXIS2': 1100, 'DATE-OBS': '2015-02-19T13:56:05.261'}
         data_file = DataFile(self.file, file_metadata=headers, required_headers=[])

--- a/tests/test_datafiles.py
+++ b/tests/test_datafiles.py
@@ -4,6 +4,8 @@ import os
 from datetime import timedelta
 from dateutil.parser import parse
 
+import responses
+
 from ocs_archive.input.file import File, DataFile, EmptyFile, FileSpecificationException
 from ocs_archive.input.fitsfile import FitsFile
 from ocs_archive.input.filefactory import FileFactory
@@ -28,7 +30,7 @@ class TestDataFile(unittest.TestCase):
         header_data = data_file.get_header_data()
         self.assertEqual('20200131', header_data.get_observation_day())
 
-    @patch.dict(os.environ, {'PUBLIC_PROPOSALS': 'EPOTHING'})
+    @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSALS', ('EPOTHING',))
     def test_public_date_public_file(self):
         headers = {
             'PROPID': 'EPOTHING',
@@ -39,7 +41,7 @@ class TestDataFile(unittest.TestCase):
         header_data = data_file.get_header_data()
         self.assertEqual(header_data.get_public_date(), header_data.get_observation_date())
 
-    @patch.dict(os.environ, {'DAYS_UNTIL_PUBLIC': '365'})
+    @patch('ocs_archive.input.file.settings.DAYS_UNTIL_PUBLIC', 365)
     def test_public_date_normal_file(self):
         headers = {
             'PROPID': 'LCO2015',
@@ -51,7 +53,7 @@ class TestDataFile(unittest.TestCase):
         public_date = (parse(header_data.get_observation_date()) + timedelta(days=settings.DAYS_UNTIL_PUBLIC)).isoformat()
         self.assertEqual(header_data.get_public_date(), public_date)
 
-    @patch.dict(os.environ, {'PRIVATE_FILE_TYPES': '-t00'})
+    @patch('ocs_archive.input.file.settings.PRIVATE_FILE_TYPES', ('-t00',))
     def test_public_date_private_t00(self):
         tst_file = EmptyFile('whatever-t00.file')
         headers = {
@@ -63,7 +65,7 @@ class TestDataFile(unittest.TestCase):
         header_data = data_file.get_header_data()
         self.assertEqual(header_data.get_public_date(), '3014-08-03T00:00:00+00:00')
 
-    @patch.dict(os.environ, {'PRIVATE_FILE_TYPES': '-x00'})
+    @patch('ocs_archive.input.file.settings.PRIVATE_FILE_TYPES', ('-x00',))
     def test_public_date_private_x00(self):
         tst_file = EmptyFile('whatever-x00.file')
         headers = {
@@ -75,7 +77,7 @@ class TestDataFile(unittest.TestCase):
         header_data = data_file.get_header_data()
         self.assertEqual(header_data.get_public_date(), '3014-08-03T00:00:00+00:00')
 
-    @patch.dict(os.environ, {'PRIVATE_PROPOSALS': 'LCOEngineering'})
+    @patch('ocs_archive.input.file.settings.PRIVATE_PROPOSALS', ('LCOEngineering',))
     def test_public_date_private_LCOEngineering(self):
         headers = {
             'PROPID': 'LCOEngineering',
@@ -96,6 +98,72 @@ class TestDataFile(unittest.TestCase):
         data_file = DataFile(self.file, file_metadata=headers, required_headers=[])
         header_data = data_file.get_header_data()
         self.assertEqual(header_data.get_public_date(), '2099-04-01T00:00:00+00:00')
+
+    @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSALS', ('EPOTHING',))
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_BASE_URL', 'https://obs.portal/')
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_API_TOKEN', 'asdf')
+    @patch('ocs_archive.input.file.settings.PRIVATE_PROPOSAL_TAGS', ('private',))
+    @responses.activate
+    def test_private_in_portal_overrides_public_environment_variable(self):
+        headers = {
+            'PROPID': 'EPOTHING',
+            'DATE-OBS': '2016-04-01T00:00:00+00:00',
+            'OBSTYPE': 'EXPOSE'
+        }
+        responses.add(responses.GET, 'https://obs.portal/api/proposals/EPOTHING',
+                      json={'tags': ['private']})
+        data_file = DataFile(self.file, file_metadata=headers, required_headers=[])
+        header_data = data_file.get_header_data()
+        self.assertEqual(header_data.get_public_date(), '3014-08-03T00:00:00+00:00')
+
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_BASE_URL', 'https://obs.portal/')
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_API_TOKEN', 'asdf')
+    @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSAL_TAGS', ('public',))
+    @responses.activate
+    def test_public_in_portal(self):
+        headers = {
+            'PROPID': 'EPOTHING',
+            'DATE-OBS': '2016-04-01T00:00:00+00:00',
+            'OBSTYPE': 'EXPOSE'
+        }
+        responses.add(responses.GET, 'https://obs.portal/api/proposals/EPOTHING',
+                      json={'tags': ['public']})
+        data_file = DataFile(self.file, file_metadata=headers, required_headers=[])
+        header_data = data_file.get_header_data()
+        self.assertEqual(header_data.get_public_date(), header_data.get_observation_date())
+
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_BASE_URL', 'https://obs.portal/')
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_API_TOKEN', 'asdf')
+    @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSAL_TAGS', ('private',))
+    @responses.activate
+    def test_private_in_portal(self):
+        headers = {
+            'PROPID': 'MyPrivateProposal',
+            'DATE-OBS': '2016-04-01T00:00:00+00:00',
+            'OBSTYPE': 'EXPOSE'
+        }
+        responses.add(responses.GET, 'https://obs.portal/api/proposals/MyPrivateProposal',
+                      json={'tags': ['private']})
+        data_file = DataFile(self.file, file_metadata=headers, required_headers=[])
+        header_data = data_file.get_header_data()
+        self.assertEqual(header_data.get_public_date(), '3014-08-03T00:00:00+00:00')
+
+    @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSALS', ('EPOTHING',))
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_BASE_URL', 'https://obs.portal/')
+    @patch('ocs_archive.input.file.settings.OBSERVATION_PORTAL_API_TOKEN', 'asdf')
+    @patch('ocs_archive.input.file.settings.PUBLIC_PROPOSAL_TAGS', ('private',))
+    @responses.activate
+    def test_no_data_privacy_tags_falls_back_to_environment_variables(self):
+        headers = {
+            'PROPID': 'EPOTHING',
+            'DATE-OBS': '2016-04-01T00:00:00+00:00',
+            'OBSTYPE': 'EXPOSE'
+        }
+        responses.add(responses.GET, 'https://obs.portal/api/proposals/EPOTHING',
+                      json={'tags': ['foo']})
+        data_file = DataFile(self.file, file_metadata=headers, required_headers=[])
+        header_data = data_file.get_header_data()
+        self.assertEqual(header_data.get_public_date(), header_data.get_observation_date())
 
     def test_get_wcs_corners_from_dict_for_ccd(self):
         headers = {'CD1_1': 6, 'CD1_2': 2, 'CD2_1': 3, 'CD2_2': 4, 'NAXIS1': 1000, 'NAXIS2': 1100, 'DATE-OBS': '2015-02-19T13:56:05.261'}


### PR DESCRIPTION
Adds some configuration to configure a connection to the obs portal and the ability to configure a set of proposal tags that dictate data privacy rules. When ingesting a frame, check if any of these tags exist in a proposal - if they do, use them to set the public date. If not, fall back to original logic contained in PUBLIC_PROPOSALS and PRIVATE_PROPOSALS. Add some tests.